### PR TITLE
修复pip安装时的编码错误

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     description=(
         "Python Dubbo Client"
     ),
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     keywords=(
         "Dubbo, JSON-RPC, JSON, RPC, Client,"
         "HTTP-Client, Remote Procedure Call, JavaScript Object Notation, "


### PR DESCRIPTION
# 修复pip安装时提示的编码错误，如下：
```python
long_description = open("README.md").read(),
    UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 74: illegal multibyte sequence
```