### PR TITLE
support dubbo protocol.

### DIFF
--- a/dubbo_client/common.py
+++ b/dubbo_client/common.py
@@ -21,6 +21,7 @@ from urlparse import urlparse, parse_qsl
 
 class ServiceURL(object):
     protocol = 'jsonrpc'
+    interface = ''
     location = ''  # ip+port
     path = ''  # like /com.qianmi.dubbo.UserProvider
     ip = '127.0.0.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bunch==1.0.1
-kazoo==2.0
+kazoo==2.4
 py==1.4.26
 pytest==2.7.0
 python-jsonrpc==0.7.3
 wsgiref==0.1.2
+python-dubbo==0.0.5

--- a/tests/test_rpclib.py
+++ b/tests/test_rpclib.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     config = ApplicationConfig('test_rpclib')
     service_interface = 'com.ofpay.demo.api.UserProvider'
     # 该对象较重，有zookeeper的连接，需要保存使用
-    registry = ZookeeperRegistry('115.28.74.185:2181', config)
+    registry = ZookeeperRegistry('127.0.0.1:2181', config)
     # registry = MulticastRegistry('224.5.6.7:1234', config)
     user_provider = DubboClient(service_interface, registry, version='2.0')
     for i in range(1000):


### PR DESCRIPTION
整合 dubbo-python2，支持jsonrpc\dubbo两种协议，同时解决dubbo-python2中不支持group和version的问题.

fixed #22, #19 
fixed https://github.com/apache/dubbo-python2/issues/5 https://github.com/apache/dubbo-python2/issues/3