### PR TITLE
Specification of encoding: issue #29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     description=(
         "Python Dubbo Client"
     ),
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding='utf-8').read(),
     keywords=(
         "Dubbo, JSON-RPC, JSON, RPC, Client,"
         "HTTP-Client, Remote Procedure Call, JavaScript Object Notation, "


### PR DESCRIPTION
As per issue #29 there was a discrepancy while running the setup.py file. This was because there was an issue with decoding a  README.md using the 'cp1252' codec.
 
 The new code added to resolve this issue is:
 
 ` long_description=open("README.md", encoding='utf-8').read(),`
 
 error before:

![Screenshot 2024-02-20 201054](https://github.com/apache/dubbo-python/assets/87228155/38bbd4b1-5f14-4215-a7ef-677ec907b330)

Now: 

![image](https://github.com/apache/dubbo-python/assets/87228155/45c64988-1185-4b67-816d-77b2ca78ae81)

