### PR TITLE
Remove redundant case-sensitive RpcType name check

### DIFF
--- a/src/dubbo/types.py
+++ b/src/dubbo/types.py
@@ -57,6 +57,4 @@ class RpcTypes(enum.Enum):
             # ignore case
             if item.value.name.lower() == name.lower():
                 return item.value
-            if item.value.name == name:
-                return item.value
         raise ValueError(f"Unknown RpcType name: {name}")


### PR DESCRIPTION
## What is the purpose of the change

Since the case-insensitive comparison already covers all scenarios, the case-sensitive one is unnecessary and can be safely removed.  The code becomes more efficient and cleaner by removing the redundant check.





<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
- [x] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
