### PR TITLE
bugfix: fix transport exception when multi client connect to same ser…

### DIFF
--- a/src/dubbo/protocol/triple/protocol.py
+++ b/src/dubbo/protocol/triple/protocol.py
@@ -77,6 +77,7 @@ class TripleProtocol(Protocol):
         # Create a stream handler
         stream_multiplexer = StreamServerMultiplexHandler(listener_factory)
         # set stream handler and protocol
+        url.attributes[aio_constants.LISTENER_FACTORY_KEY] = listener_factory
         url.attributes[aio_constants.STREAM_HANDLER_KEY] = stream_multiplexer
         url.attributes[common_constants.PROTOCOL_KEY] = Http2ServerProtocol
 

--- a/src/dubbo/remoting/aio/constants.py
+++ b/src/dubbo/remoting/aio/constants.py
@@ -18,6 +18,8 @@ __all__ = ["STREAM_HANDLER_KEY"]
 
 STREAM_HANDLER_KEY = "stream-handler"
 
+LISTENER_FACTORY_KEY = "listener-factory"
+
 CLOSE_FUTURE_KEY = "close-future"
 
 HEARTBEAT_KEY = "heartbeat"

--- a/src/dubbo/remoting/aio/http2/protocol.py
+++ b/src/dubbo/remoting/aio/http2/protocol.py
@@ -22,9 +22,11 @@ from typing import Optional
 from h2.config import H2Configuration
 from h2.connection import H2Connection
 
+from dubbo.constants import common_constants
 from dubbo.loggers import loggerFactory
 from dubbo.remoting.aio import ConnectionStateListener, EmptyConnectionStateListener, constants as h2_constants
 from dubbo.remoting.aio.exceptions import ProtocolError
+from dubbo.remoting.aio.http2.stream_handler import StreamServerMultiplexHandler, StreamClientMultiplexHandler
 from dubbo.remoting.aio.http2.controllers import RemoteFlowController
 from dubbo.remoting.aio.http2.frames import (
     DataFrame,
@@ -76,7 +78,11 @@ class AbstractHttp2Protocol(asyncio.Protocol, abc.ABC):
 
         self._flow_controller: Optional[RemoteFlowController] = None
 
-        self._stream_handler = self._url.attributes[h2_constants.STREAM_HANDLER_KEY]
+        if self._url.attributes[common_constants.PROTOCOL_KEY] == Http2ServerProtocol:
+            listener_factory = self._url.attributes[h2_constants.LISTENER_FACTORY_KEY]
+            self._stream_handler = StreamServerMultiplexHandler(listener_factory)
+        else:
+            self._stream_handler = self._url.attributes[h2_constants.STREAM_HANDLER_KEY]
 
         # last time of receiving data
         self._last_read = time.time()

--- a/src/dubbo/remoting/aio/http2/protocol.py
+++ b/src/dubbo/remoting/aio/http2/protocol.py
@@ -26,7 +26,7 @@ from dubbo.constants import common_constants
 from dubbo.loggers import loggerFactory
 from dubbo.remoting.aio import ConnectionStateListener, EmptyConnectionStateListener, constants as h2_constants
 from dubbo.remoting.aio.exceptions import ProtocolError
-from dubbo.remoting.aio.http2.stream_handler import StreamServerMultiplexHandler, StreamClientMultiplexHandler
+from dubbo.remoting.aio.http2.stream_handler import StreamServerMultiplexHandler
 from dubbo.remoting.aio.http2.controllers import RemoteFlowController
 from dubbo.remoting.aio.http2.frames import (
     DataFrame,


### PR DESCRIPTION
## What is the purpose of the change

The Http2Protocol stream-handler object is set by the `triple/protocol.py' defined when initialized.

When client connect to server, the asyncio will create a new http2protol using the same stream-handler object, and overwrite the _loop property. it results that the previous connections cannnot be resolved as expected.

It could be resolved by redefine the stream-handler in Http2Protocol


## Brief changelog


## Verifying this change
